### PR TITLE
Email Send API

### DIFF
--- a/backend/api/endpoints/share.py
+++ b/backend/api/endpoints/share.py
@@ -1,1 +1,46 @@
-# 共有のapiエンドポイント
+from fastapi import APIRouter, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+import smtplib
+from email.mime.base import MIMEBase
+from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
+from email import encoders
+
+from backend import schemas
+from backend.core.config import settings
+from backend.exceptions.core import APIException
+from backend.exceptions.error_messages import ErrorMessage
+
+router = APIRouter()
+
+
+@router.post("/send")
+async def send_mail(
+    email: schemas.EmailSend,
+):
+    msg = MIMEMultipart()
+    msg["From"] = settings.MAIL_FROM
+    msg["To"] = ", ".join(email.to)
+    msg["Subject"] = email.subject
+    msg.attach(MIMEText(email.body, "plain"))
+
+    if email.attachment:
+        attachment_file = schemas.EmailSend.validate_attachment(email.attachment)
+        try:
+            part = MIMEBase("application", "octet-stream")
+            part.set_payload(attachment_file.file.read())
+            encoders.encode_base64(part)
+            part.add_header(
+                "Content-Disposition",
+                f"attachment; filename={attachment_file.filename}",
+            )
+            msg.attach(part)
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"添付ファイルの処理中にエラーが発生しました: {str(e)}")
+
+    with smtplib.SMTP(settings.MAIL_SERVER, settings.MAIL_PORT) as server:
+        server.starttls()
+        server.login(settings.MAIL_FROM, settings.MAIL_PASSWORD)
+        server.send_message(msg)
+
+    return {"message": "Email has been sent"}

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -33,6 +33,11 @@ class Settings(BaseSettings):
     SENTRY_SDK_DNS: str = ""
     MIGRATIONS_DIR_PATH: str = os.path.join(ROOT_DIR_PATH, "alembic")
 
+    MAIL_FROM: str = "driverlisenceapp@gmail.com"
+    MAIL_PASSWORD: str = "pycbhcghywsbszts"
+    MAIL_PORT: int = 587
+    MAIL_SERVER: str = "smtp.gmail.com"
+
     def get_database_url(self, is_async: bool = False) -> str:
         if is_async:
             postgresql_url = "postgresql+asyncpg://"f"{self.DB_USER_NAME}:{self.DB_PASSWORD}@"f"{self.DB_HOST}/{self.DB_NAME}"

--- a/backend/main.py
+++ b/backend/main.py
@@ -45,7 +45,7 @@ app.include_router(users.router, tags=["Users"], prefix="/users")
 # app.include_router(families.router, tags=["Families"], prefix="/families")
 # app.include_router(reports.router, tags=["Reports"], prefix="/drive_reports")
 # app.include_router(sensors.router, tags=["Sensors"], prefix="/drive_sensors")
-# app.include_router(share.router, tags=["Share"], prefix="/email")
+app.include_router(share.router, tags=["Share"], prefix="/email")
 
 # debugモード時はfastapi-tool-barを有効化する
 if settings.DEBUG:

--- a/backend/schemas/__init__.py
+++ b/backend/schemas/__init__.py
@@ -2,3 +2,4 @@ from .core import BaseSchema, PagingMeta, PagingQueryIn, SortQueryIn
 from .request_info import RequestInfoResponse
 from .token import Token, TokenPayload
 from .users import UserCreate, UserResponse, UsersPagedResponse, UserUpdate
+from .share import EmailSend

--- a/backend/schemas/share.py
+++ b/backend/schemas/share.py
@@ -1,0 +1,57 @@
+from pydantic import EmailStr, Field
+from typing import List, Optional
+from fastapi import UploadFile, HTTPException
+import base64
+import tempfile
+import imghdr
+
+from backend.schemas.core import BaseSchema
+
+
+class EmailSend(BaseSchema):
+    to: List[EmailStr] = Field(...)
+    subject: str = Field(..., max_length=100)
+    body: str = Field(...)
+    attachment: Optional[str] = Field(None)
+
+    @staticmethod
+    def validate_attachment(attachment: Optional[str]):
+        if not attachment:
+            return None
+
+        # ファイルサイズ制限（例: 5MB）
+        max_file_size = 5 * 1024 * 1024  # 5MB
+        # 許可される拡張子
+        allowed_formats = {"pdf", "png", "jpg", "jpeg", "docx", "txt"}
+
+        try:
+            # デコードしてバイナリデータを取得
+            header, data = attachment.split(",", 1)
+            file_data = base64.b64decode(data)
+
+            # サイズチェック
+            if len(file_data) > max_file_size:
+                raise ValueError("添付ファイルのサイズは5MB以下である必要があります。")
+
+            # MIMEタイプや拡張子を推測
+            if "image" in header:
+                ext = imghdr.what(None, file_data)
+                if ext not in allowed_formats:
+                    raise ValueError(f"添付ファイルの形式は次のいずれかである必要があります: {', '.join(allowed_formats)}")
+            else:
+                ext = header.split(";")[0].split("/")[-1]
+                if ext not in allowed_formats:
+                    raise ValueError(f"添付ファイルの形式は次のいずれかである必要があります: {', '.join(allowed_formats)}")
+            
+            # 一時ファイルに保存（UploadFile互換のオブジェクトとして扱う）
+            temp_file = tempfile.NamedTemporaryFile(delete=False)
+            temp_file.write(file_data)
+            temp_file.close()
+
+            return UploadFile(
+                filename=f"decoded_file.{ext}",
+                file=open(temp_file.name, "rb")
+            )
+
+        except (ValueError, base64.binascii.Error) as e:
+            raise HTTPException(status_code=400, detail=str(e))

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,11 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App'
+import EmailSendForm from './pages/FamilyProfile'
 import './index.css'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <EmailSendForm />
   </StrictMode>,
 )

--- a/frontend/src/pages/FamilyProfile.jsx
+++ b/frontend/src/pages/FamilyProfile.jsx
@@ -1,1 +1,155 @@
-// 家族のプロフィール(編集)画面
+import React, { useState, useRef } from "react";
+
+const EmailSendForm = () => {
+  const [to, setTo] = useState([]); // メールアドレスリスト
+  const [subject, setSubject] = useState(""); // 件名
+  const [body, setBody] = useState(""); // 本文
+  const [attachment, setAttachment] = useState(null); // 添付ファイル
+  const [errorMessage, setErrorMessage] = useState(null); // エラーメッセージ
+  const [successMessage, setSuccessMessage] = useState(null); // 成功メッセージ
+
+  const emailRef = useRef(); // メールアドレス入力の参照
+
+  // メールアドレスを追加
+  const handleAddEmail = (e) => {
+    e.preventDefault();
+    const newEmail = emailRef.current.value;
+
+    // 入力されていない場合は何もしない
+    if (newEmail && !to.includes(newEmail)) {
+      setTo((prevTo) => [...prevTo, newEmail]); // 新しいメールアドレスをリストに追加
+    }
+
+    emailRef.current.value = "";  // フィールドをリセット
+  };
+
+  // 添付ファイルの状態更新
+  const handleFileChange = (e) => {
+    setAttachment(e.target.files[0]);
+  };
+
+  // フォーム送信時
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+
+    // 入力チェック
+    if (to.length === 0 || !subject || !body) {
+      setErrorMessage("送信先、件名、本文は必須です。");
+      return;
+    }
+
+    if (attachment) {
+      const reader = new FileReader();
+      reader.readAsDataURL(attachment);
+      reader.onload = async() => {
+        const attachmentBase64 = reader.result;
+        const payload = {
+          to: to,
+          subject: subject,
+          body: body,
+          attachment: attachmentBase64,
+        };
+
+        try {
+          const response = await fetch("http://localhost:8000/email/send", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify(payload),
+          });
+
+          if (!response.ok) {
+            throw new Error("メール送信に失敗しました。");
+          }
+
+          const data = await response.json();
+          setSuccessMessage(data.message);
+          setErrorMessage(null);
+        } catch (error) {
+          setSuccessMessage(null);
+          setErrorMessage(error.message);
+        }
+      };
+    } else {
+      const payload = {
+        to: to,
+        subject: subject,
+        body: body,
+        attachment: null,
+      };
+      try {
+        const response = await fetch("http://localhost:8000/email/send", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(payload),
+        });
+
+        if (!response.ok) {
+          throw new Error("メール送信に失敗しました。");
+        }
+
+        const data = await response.json();
+        setSuccessMessage(data.message);
+        setErrorMessage(null);
+      } catch (error) {
+        setSuccessMessage(null);
+        setErrorMessage(error.message);
+      }
+    }
+  }
+
+  return (
+    <div>
+      <h1>メール送信フォーム</h1>
+      {errorMessage && <p style={{ color: "red" }}>{errorMessage}</p>}
+      {successMessage && <p style={{ color: "green" }}>{successMessage}</p>}
+      <form onSubmit={handleSubmit}>
+        <div>
+          <label>送信先 (メールアドレスを追加):</label>
+          <input
+            type="email"
+            ref={emailRef} // refで入力欄を管理
+          />
+          <button onClick={handleAddEmail}>追加</button>
+          <ul>
+            {to.map((email, index) => (
+              <li key={index}>{email}</li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <label>件名:</label>
+          <input
+            type="text"
+            value={subject}
+            onChange={(e) => setSubject(e.target.value)}
+            required
+            maxLength={100}
+          />
+        </div>
+        <div>
+          <label>本文:</label>
+          <textarea
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <label>添付ファイル (オプション):</label>
+          <input
+            type="file"
+            onChange={handleFileChange}
+            accept=".pdf,.png,.jpg,.jpeg,.docx,.txt"
+          />
+        </div>
+        <button type="submit">送信</button>
+      </form>
+    </div>
+  );
+};
+
+export default EmailSendForm;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ dependencies = [
     "asyncpg>=0.30.0",
     "ulid-py>=1.1.0",
     "aiosqlite>=0.20.0",
+    "fastapi-mail>=1.4.2",
+    "python-multipart>=0.0.20",
 ]
 readme = "README.md"
 requires-python = ">= 3.8"

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -10,6 +10,8 @@
 #   universal: false
 
 -e file:.
+aiosmtplib==3.0.2
+    # via fastapi-mail
 aiosqlite==0.20.0
     # via driver-lisence
 alembic==1.14.0
@@ -23,6 +25,8 @@ anyio==4.7.0
     # via watchfiles
 asyncpg==0.30.0
     # via driver-lisence
+blinker==1.9.0
+    # via fastapi-mail
 certifi==2024.12.14
     # via httpcore
     # via httpx
@@ -38,12 +42,15 @@ ecdsa==0.19.0
     # via python-jose
 email-validator==2.2.0
     # via fastapi
+    # via fastapi-mail
 fastapi==0.115.6
     # via driver-lisence
     # via fastapi-debug-toolbar
 fastapi-cli==0.0.7
     # via fastapi
 fastapi-debug-toolbar==0.6.3
+    # via driver-lisence
+fastapi-mail==1.4.2
     # via driver-lisence
 greenlet==3.1.1
     # via sqlalchemy
@@ -65,6 +72,7 @@ itsdangerous==2.2.0
 jinja2==3.1.4
     # via fastapi
     # via fastapi-debug-toolbar
+    # via fastapi-mail
 jose==1.0.0
     # via driver-lisence
 mako==1.3.8
@@ -88,6 +96,7 @@ pyasn1==0.6.1
 pydantic==2.10.3
     # via fastapi
     # via fastapi-debug-toolbar
+    # via fastapi-mail
     # via pydantic-extra-types
     # via pydantic-settings
 pydantic-core==2.27.1
@@ -99,6 +108,7 @@ pydantic-settings==2.7.0
     # via driver-lisence
     # via fastapi
     # via fastapi-debug-toolbar
+    # via fastapi-mail
 pygments==2.18.0
     # via rich
 pyinstrument==5.0.0
@@ -108,7 +118,8 @@ python-dotenv==1.0.1
     # via uvicorn
 python-jose==3.3.0
     # via driver-lisence
-python-multipart==0.0.19
+python-multipart==0.0.20
+    # via driver-lisence
     # via fastapi
 pyyaml==6.0.2
     # via fastapi
@@ -134,6 +145,7 @@ sqlparse==0.5.3
     # via fastapi-debug-toolbar
 starlette==0.41.3
     # via fastapi
+    # via fastapi-mail
 typer==0.15.1
     # via fastapi-cli
 typing-extensions==4.12.2

--- a/requirements.lock
+++ b/requirements.lock
@@ -10,6 +10,8 @@
 #   universal: false
 
 -e file:.
+aiosmtplib==3.0.2
+    # via fastapi-mail
 aiosqlite==0.20.0
     # via driver-lisence
 alembic==1.14.0
@@ -23,6 +25,8 @@ anyio==4.7.0
     # via watchfiles
 asyncpg==0.30.0
     # via driver-lisence
+blinker==1.9.0
+    # via fastapi-mail
 certifi==2024.12.14
     # via httpcore
     # via httpx
@@ -38,12 +42,15 @@ ecdsa==0.19.0
     # via python-jose
 email-validator==2.2.0
     # via fastapi
+    # via fastapi-mail
 fastapi==0.115.6
     # via driver-lisence
     # via fastapi-debug-toolbar
 fastapi-cli==0.0.7
     # via fastapi
 fastapi-debug-toolbar==0.6.3
+    # via driver-lisence
+fastapi-mail==1.4.2
     # via driver-lisence
 greenlet==3.1.1
     # via sqlalchemy
@@ -65,6 +72,7 @@ itsdangerous==2.2.0
 jinja2==3.1.4
     # via fastapi
     # via fastapi-debug-toolbar
+    # via fastapi-mail
 jose==1.0.0
     # via driver-lisence
 mako==1.3.8
@@ -88,6 +96,7 @@ pyasn1==0.6.1
 pydantic==2.10.3
     # via fastapi
     # via fastapi-debug-toolbar
+    # via fastapi-mail
     # via pydantic-extra-types
     # via pydantic-settings
 pydantic-core==2.27.1
@@ -99,6 +108,7 @@ pydantic-settings==2.7.0
     # via driver-lisence
     # via fastapi
     # via fastapi-debug-toolbar
+    # via fastapi-mail
 pygments==2.18.0
     # via rich
 pyinstrument==5.0.0
@@ -108,7 +118,8 @@ python-dotenv==1.0.1
     # via uvicorn
 python-jose==3.3.0
     # via driver-lisence
-python-multipart==0.0.19
+python-multipart==0.0.20
+    # via driver-lisence
     # via fastapi
 pyyaml==6.0.2
     # via fastapi
@@ -134,6 +145,7 @@ sqlparse==0.5.3
     # via fastapi-debug-toolbar
 starlette==0.41.3
     # via fastapi
+    # via fastapi-mail
 typer==0.15.1
     # via fastapi-cli
 typing-extensions==4.12.2


### PR DESCRIPTION
# プルリクエストの概要

## 該当Issue
- 関連するIssue番号を記載してください。
  - Issue番号: #12

---

## 変更点
- 具体的な変更内容を記載してください（機能追加、修正、リファクタリングなど）。
  - [x] **機能追加**: 
    - メールアドレスのリスト,件名,本文,添付ファイル(オプション)を渡すとメールを送るapiを追加
    - 送信元のメールアドレスは、本アプリ用に作成したdriverlisenceapp@gmail.comとなっている
  - [ ] **バグ修正**: 
    - 修正した箇所を記載
  - [ ] **リファクタリング**: 
    - 簡潔な説明を記載

---

## 動作確認
- 動作確認の手順を記載してください。
  1. **テスト手順**:
      - 使用したコマンド:
        - rye run uvicorn backend.main:app を実行しバックエンドを起動
        - frontend/でnpm run dev を実行しフロントエンドを起動
        - 送信したいメールアドレスを追加、件名と本文を入力、添付ファイルを指定し、送信ボタンを押す
      - 確認すべき動作:
        - 指定した内容のメールが送信される
        - 添付ファイルの有無にかかわらず送信できる
        - 件名が100字以上である、添付ファイルが5MB以上である、または拡張子がpdf, png, jpg, jpeg, docx, txt 以外である場合は送信に失敗する
  2. **環境**:
      - OS: wsl
      - バージョン: 2.3.26.0

- その他の確認項目:
  - [x] ユニットテストが成功しているか
  - [ ] 必要なドキュメントが更新されているか
  - [ ] コードフォーマットが適切であるか
